### PR TITLE
Start of docs branch. gulp task added (gulp docs) that:

### DIFF
--- a/gulp/tasks/docs.js
+++ b/gulp/tasks/docs.js
@@ -1,0 +1,7 @@
+var gulp = require('gulp');
+
+var ghpages = require('gh-pages');
+var path = require('path');
+gulp.task('docs', ['build'], function (done) {
+  ghpages.publish(path.join(__dirname, '../../examples'), function(err) { throw err; });
+});

--- a/gulp/tasks/docs.js
+++ b/gulp/tasks/docs.js
@@ -2,6 +2,6 @@ var gulp = require('gulp');
 
 var ghpages = require('gh-pages');
 var path = require('path');
-gulp.task('docs', ['build'], function (done) {
+gulp.task('docs', ['examples'], function (done) {
   ghpages.publish(path.join(__dirname, '../../examples'), function(err) { throw err; });
 });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "gulp test",
-    "prepublish" : "gulp dist"
+    "prepublish": "gulp dist"
   },
   "repository": {
     "type": "git",
@@ -69,7 +69,8 @@
     "rewire-webpack": "^1.0.0",
     "sinon": "^1.9.1",
     "vinyl-source-stream": "^0.1.1",
-    "webpack": "^1.4.7"
+    "webpack": "^1.4.7",
+    "gh-pages": "~0.2.0"
   },
   "author": "Prometheus Research",
   "license": "MIT",


### PR DESCRIPTION
DOES:
Do a gulp build
package everything under examples
push that to the gh-pages branch
BUT..
index.html refs ./examples/build/app.js (etc)
our folder structure is ./build/app.js (etc) < so needs to be manually edited
(err, and jshint means the build fails, so sort of need that fixed 1st!)